### PR TITLE
Support for netatmo smokedetectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .DS_Store
 .idea/
 package-lock.json
+
+
+# ioBroker dev-server
+.dev-server/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ the personsId is the id within the "Known" persons folder
 -->
 ## Changelog
 
+### 1.4.5 (2021-12-29)
+* (kyuka-dom) Added support for netatmo smoke alarm.
+
 ### 1.4.4 (2021-07-21)
 * (Apollon77) Fix typo that lead to a crash
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -22,6 +22,7 @@
         "Coach": {"de": "Health Coach", "en": "Healthy Coach"},
         "Weather": {"de": "Wetter Station", "en": "weather station"},
         "Welcome": {"de": "Welcome Innenkamera", "en": "welcome indoor cam"},
+        "Smokedetector": {"de": "Rauchmelder", "en": "smoke detector"},
         "on save adapter restarts with new config immediately": {
             "de": "Beim Speichern von Einstellungen wird der Adapter sofort neu gestartet.",
             "ru": "Сразу после сохранения настроек драйвер перезапуститься с новыми значениями"
@@ -110,6 +111,10 @@
 			<td class="translate">Welcome</td>
 			<td><input type="checkbox" id="netatmoWelcome" value="true" class="value"></td>
 		</tr>
+        <tr>
+			<td class="translate">Smokedetector</td>
+			<td><input type="checkbox" id="netatmoSmokedetector" value="true" class="value"></td>
+		</tr>
 		<tr>
 			<td class="translate">E-Mail</td>
 			<td><input class="value" id="username"></td>
@@ -144,7 +149,7 @@
 	</table>
 
 	<br/>
-	<b class="translate">In order to receive livestreams from Welcome & Presence, you've to request your own API key from Netatmo!<br/>To do so, go to the following URL, login with your Netatmo account and fill out the requested form</b>
+	<b class="translate">In order to receive livestreams from Welcome & Presence or the smoke detector, you've to request your own API key from Netatmo!<br/>To do so, go to the following URL, login with your Netatmo account and fill out the requested form</b>
 	<a href="https://dev.netatmo.com/dev/createanapp" target="_blank">https://dev.netatmo.com/dev/createanapp</a>
 
 	<br/><br/>

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -72,8 +72,8 @@
             "en": "Remove unknown persons last seen older than"
         },
         "live_stream1": {
-            "en": "In order to receive livestreams from Welcome &amp; Presence, you've to request your own API key from Netatmo!",
-            "de": "Um Livestreams von Welcome &amp; Presence zu erhalten, musst du einen eigenen API-Schlüssel von Netatmo anfordern!",
+            "en": "In order to receive livestreams from Welcome &amp; Presence or to get realtime smoke alerts, you've to request your own API key from Netatmo!",
+            "de": "Um Livestreams von Welcome &amp; Presence zu erhalten oder Rauchmeldungen in Echtzeit, musst du einen eigenen API-Schlüssel von Netatmo anfordern!",
             "ru": "Чтобы получать прямые трансляции от Welcome & amp; Присутствие, вы должны запросить собственный ключ API у Netatmo!"
         },
         "live_stream2": {
@@ -160,17 +160,17 @@
             "lg": 3
         },
         "_header": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "header",
             "size": 4,
             "style": {
                 "marginTop": 20
             },
             "sm": 12,
-            "text": "Welcome & presence camera"
+            "text": "Welcome & presence camera & smoke detector"
         },
         "cleanup_interval": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "number",
             "label": "CleanupIntervall",
             "help": "clean minutes",
@@ -178,7 +178,7 @@
             "lg": 3
         },
         "event_time": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "newLine": true,
             "type": "number",
             "label": "RemoveEvents",
@@ -195,26 +195,26 @@
             "lg": 3
         },
         "_text1": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "staticText",
             "newLine":  true,
             "text": "live_stream1"
         },
         "_text2": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "staticText",
             "newLine":  true,
             "text": "live_stream2"
         },
         "_link": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "newLine":  true,
             "type": "staticLink",
             "text": "https://dev.netatmo.com/apps/createanapp",
             "href": "https://auth.netatmo.com/access/login?next_url=https%3A%2F%2Fdev.netatmo.com%2Fapps%2Fcreateanapp"
         },
         "id": {
-            "hidden": "!data.netatmoWelcome || !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "text",
             "newLine": true,
             "label": "Client ID",
@@ -223,7 +223,7 @@
             "lg": 3
         },
         "secret": {
-            "hidden": "!data.netatmoWelcome || !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "password",
             "help": "Netatmo App",
             "label": "Client Secret",

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -31,6 +31,10 @@
             "de": "Welcome Innenkamera",
             "en": "Welcome indoor cam"
         },
+        "Smokedetector": {
+            "de": "Rauchmelder",
+            "en": "smoke detector"
+        },
         "ClientID": {
             "de": "Client ID",
             "en": "Client ID"
@@ -111,6 +115,13 @@
         "netatmoWelcome": {
             "type": "checkbox",
             "label": "Welcome indoor cam",
+            "sm": 12,
+            "md": 6,
+            "lg": 3
+        },
+         "netatmoSmokedetector": {
+            "type": "checkbox",
+            "label": "Smokedetector",
             "sm": 12,
             "md": 6,
             "lg": 3
@@ -203,7 +214,7 @@
             "href": "https://auth.netatmo.com/access/login?next_url=https%3A%2F%2Fdev.netatmo.com%2Fapps%2Fcreateanapp"
         },
         "id": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome || !data.netatmoSmokedetector",
             "type": "text",
             "newLine": true,
             "label": "Client ID",
@@ -212,7 +223,7 @@
             "lg": 3
         },
         "secret": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome || !data.netatmoSmokedetector",
             "type": "password",
             "help": "Netatmo App",
             "label": "Client Secret",

--- a/io-package.json
+++ b/io-package.json
@@ -9,7 +9,7 @@
         "news": {
             "1.4.5": {
                 "en": "added support for netatmo smokedetector",
-                "de": "Unterstützung für Netatmo Rauchmelder hinzugefügt.",
+                "de": "Unterstützung für Netatmo Rauchmelder hinzugefügt."
             },
             "1.4.4": {
                 "en": "Fix typo that lead to a crash",

--- a/io-package.json
+++ b/io-package.json
@@ -1,12 +1,16 @@
 {
     "common": {
         "name": "netatmo",
-        "version": "1.4.4",
+        "version": "1.4.5",
         "title": "Netatmo",
         "titleLang": {
             "en": "Netatmo"
         },
         "news": {
+            "1.4.5": {
+                "en": "added support for netatmo smokedetector",
+                "de": "Unterstützung für Netatmo Rauchmelder hinzugefügt.",
+            },
             "1.4.4": {
                 "en": "Fix typo that lead to a crash",
                 "de": "Tippfehler behoben, der zu einem Absturz führte",
@@ -122,6 +126,7 @@
         "netatmoWeather": true,
         "netatmoWelcome": false,
         "netatmoCoach": false,
+        "netatmoSmokedetector": false,
         "username": "",
         "password": "",
         "check_interval": 5,

--- a/lib/netatmoSmokedetector.js
+++ b/lib/netatmoSmokedetector.js
@@ -3,12 +3,9 @@ module.exports = function (myapi, myadapter) {
     const adapter = myadapter;
     const cleanUpInterval = adapter.config.cleanup_interval ? adapter.config.cleanup_interval : 5;
     const EventTime = adapter.config.event_time ? adapter.config.event_time : 12;
-    const UnknownPersonTime = adapter.config.unknown_person_time ? adapter.config.unknown_person_time : 24;
 
     const eventCleanUpTimer = {};
-    const personCleanUpTimer = {};
 
-    let knownPeople = [];
     let homeIds = [];
 
     let socket = null;
@@ -87,7 +84,7 @@ module.exports = function (myapi, myadapter) {
                 await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: true, ack: true});
                 // reset event after 10 sec
                 setTimeout(async () => {
-                    await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: false, ack: false});
+                    await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: false, ack: true});
                 }, 10 * 1000);
             }
         }

--- a/lib/netatmoSmokedetector.js
+++ b/lib/netatmoSmokedetector.js
@@ -1,0 +1,444 @@
+module.exports = function (myapi, myadapter) {
+    const api = myapi;
+    const adapter = myadapter;
+    const cleanUpInterval = adapter.config.cleanup_interval ? adapter.config.cleanup_interval : 5;
+    const EventTime = adapter.config.event_time ? adapter.config.event_time : 12;
+    const UnknownPersonTime = adapter.config.unknown_person_time ? adapter.config.unknown_person_time : 24;
+
+    const eventCleanUpTimer = {};
+    const personCleanUpTimer = {};
+
+    let knownPeople = [];
+    let homeIds = [];
+
+    let socket = null;
+    let that = null;
+
+    const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
+
+    this.init = function () {
+        that = this;
+        socket = require('socket.io-client')(socketServerUrl);
+
+        if (socket) {
+            adapter.log.info(`Registering realtime events with ${socketServerUrl}`);
+            socket.on('alert', async data => await onSocketAlert(data));
+            api.addWebHook(socketServerUrl);
+        }
+    };
+
+    this.finalize = function () {
+        if (socket) {
+            adapter.log.info('Unregistering realtime events');
+            socket.disconnect();
+            api.dropWebHook();
+        }
+        Object.keys(eventCleanUpTimer).forEach(id => clearInterval(eventCleanUpTimer[id]));
+    };
+
+
+    this.requestUpdateSmokedetector = function () {
+        return new Promise(resolve => {
+            api.getHomeData({}, async (err, data) => {
+                if (err !== null) {
+                    adapter.log.error(err);
+                } else {
+                    const homes = data.homes;
+                    homeIds = [];
+
+                    if (Array.isArray(homes)) {
+                        for (let h = 0; h < homes.length; h++) {
+                            const aHome = homes[h];
+
+                            await handleHome(aHome);  // TODO check if it's an issue that the same homeId is subscribed twice in case of smoke & cameras
+
+                            const homeName = getHomeName(aHome.name);
+
+                            eventCleanUpTimer[homeName] =  eventCleanUpTimer[homeName] || setInterval(() =>
+                                cleanUpEvents(homeName), cleanUpInterval * 60 * 1000);
+                        }
+                    }
+                }
+                resolve();
+            });
+        });
+    };
+
+    async function onSocketAlert(data) {
+        // TODO figure out a way to ignore camera events
+        adapter.log.debug(JSON.stringify(data));
+
+        await that.requestUpdateSmokedetector();
+
+        const now = new Date().toISOString();
+
+        if (data) {
+            const path = data.home_name + '.LastEventData.';
+            const smokeDetectorEvents = ["sound_test","detection_chamber_status","battery_status","wifi_status","tampered","smoke","hush"]
+            if (smokeDetectorEvents.includes(data.event_type)) {
+                await adapter.setStateAsync(path + 'LastPushType', {val: data.push_type, ack: true});
+                await adapter.setStateAsync(path + 'LastEventType', {val: data.event_type, ack: true});
+                await adapter.setStateAsync(path + 'LastEventDeviceId', {val: data.device_id, ack: true});
+                await adapter.setStateAsync(path + 'LastEventId', {val: data.event_id, ack: true});
+                await adapter.setStateAsync(path + 'LastEvent', {val: now, ack: true});
+
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.LastEvent`, {val: now, ack: true});
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.LastEventId`, {val: data.event_id, ack: true});
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: true, ack: true});
+                // reset event after 10 sec
+                setTimeout(async () => {
+                    await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: false, ack: false});
+                }, 10 * 1000);
+            }
+        }
+    }
+
+    function getHomeName(aHomeName) {
+        return aHomeName.replaceAll(' ', '-').replaceAll('---', '-').replaceAll('--', '-');
+    }
+
+    async function handleHome(aHome) {
+        const homeName = getHomeName(aHome.name);
+        const fullPath = homeName;
+
+        homeIds.push(aHome.id);
+
+        // Join HomeID
+        if (socket) {
+            socket.emit('registerHome', aHome.id);
+        }
+
+        await adapter.setObjectNotExistsAsync(homeName, {
+            type: 'channel',
+            common: {
+                name: homeName,
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData', {
+            type: 'channel',
+            common: {
+                name: 'LastEventData',
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastPushType', {
+            type: 'state',
+            common: {
+                name: 'LastPushType',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEventId', {
+            type: 'state',
+            common: {
+                name: 'LastEventId',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEventType', {
+            type: 'state',
+            common: {
+                name: 'LastEventTypes',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEventDeviceId', {
+            type: 'state',
+            common: {
+                name: 'LastEventDeviceId',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEvent', {
+            type: 'state',
+            common: {
+                name: 'LastEvent',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+
+        if (aHome.smokedetectors) {
+            aHome.smokedetectors.forEach(async aSmokeDetector => {
+                if (aSmokeDetector.id && aSmokeDetector.name) {
+                    await adapter.setObjectNotExistsAsync(fullPath + '.' + aSmokeDetector.id, {
+                        type: 'state',
+                        common: {
+                            name: aSmokeDetector.name,
+                            type: 'string',
+                            read: true,
+                            write: false
+                        }
+                    });
+                    await adapter.setStateAsync(fullPath + '.' + aSmokeDetector.id, {val: aSmokeDetector.id, ack: true});
+                }
+            });
+        }
+
+        // Smoke Detector Objects anlegen
+        if (aHome.smokedetectors) {
+            aHome.smokedetectors.forEach(async aSmokeDetector =>
+                await handleSmokeDetector(aSmokeDetector, aHome));
+        }
+
+
+        // Disabled due to no usage ...
+        /*
+        if (aHome.events) {
+
+            const latestEventDate = 0;
+            const latestEvent = null;
+
+            aHome.events.forEach(function (aEvent) {
+                const eventDate = aEvent.time * 1000;
+
+                handleEvent(aEvent, homeName, aHome.cameras);
+                if (eventDate > latestEventDate) {
+                    latestEventDate = eventDate;
+                    latestEvent = aEvent;
+                }
+            });
+
+            if (latestEvent) {
+                await adapter.setStateAsync(homeName + '.LastEventData.LastEventId', {val: latestEvent.id, ack: true});
+            }
+        }
+         */
+    }
+
+    async function handleSmokeDetector(aSmokeDetector, aHome) {
+        const aParent = getHomeName(aHome.name);
+        const fullPath = aParent + '.' + aSmokeDetector.id;
+        const infoPath = fullPath + '.info';
+        const smokeDetectorEvents = ["sound_test","detection_chamber_status","battery_status","wifi_status","tampered","smoke","hush"]
+
+        await adapter.setObjectNotExistsAsync(fullPath, {
+            type: 'device',
+            common: {
+                name: aSmokeDetector.name,
+                type: 'device',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aSmokeDetector.id,
+                type: aSmokeDetector.type
+            }
+        });
+
+        if (aSmokeDetector.id) {
+            await adapter.setObjectNotExistsAsync(infoPath + '.id', {
+                type: 'state',
+                common: {
+                    name: 'SmokeDetector ID',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+            await adapter.setStateAsync(infoPath + '.id', {val: aSmokeDetector.id, ack: true});
+        }
+
+        
+
+        if (aSmokeDetector.name) {
+            await adapter.setObjectNotExistsAsync(infoPath + '.name', {
+                type: 'state',
+                common: {
+                    name: 'SmokeDetector name',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(infoPath + '.name', {val: aSmokeDetector.name, ack: true});
+        }
+
+        smokeDetectorEvents.forEach(async (e) => {
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}`, {
+                type: 'channel',
+                common: {
+                    name: e,
+                }
+            });
+
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.LastEventId`, {
+                type: 'state',
+                common: {
+                    name: 'LastEventId',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.LastEvent`, {
+                type: 'state',
+                common: {
+                    name: 'LastEvent',
+                    type: 'string',
+                    read: true,
+                    write: false
+                },
+                native: {
+                    id: aHome.id
+                }
+            });
+
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.active`, {
+                type: 'state',
+                common: {
+                    name: 'LastEvent',
+                    type: 'boolean',
+                    read: true,
+                    write: false
+                },
+                native: {
+                    id: aHome.id
+                }
+            });
+        })
+
+         // Initialize SmokeDetector Place
+        if (aHome.place) {
+            await handlePlace(aHome.place, fullPath);
+        }
+    }
+
+    async function handlePlace(aPlace, aParent) {
+        const fullPath = aParent + '.place';
+
+        await adapter.setObjectNotExistsAsync(fullPath, {
+            type: 'channel',
+            common: {
+                name: 'place',
+            }
+        });
+
+        if (aPlace.city) {
+            await adapter.setObjectNotExistsAsync(fullPath + '.city', {
+                type: 'state',
+                common: {
+                    name: 'city',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(fullPath + '.city', {val: aPlace.city, ack: true});
+        }
+
+        if (aPlace.country) {
+            await adapter.setObjectNotExistsAsync(fullPath + '.country', {
+                type: 'state',
+                common: {
+                    name: 'country',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(fullPath + '.country', {val: aPlace.country, ack: true});
+        }
+
+        if (aPlace.timezone) {
+            await adapter.setObjectNotExistsAsync(fullPath + '.timezone', {
+                type: 'state',
+                common: {
+                    name: 'timezone',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(fullPath + '.timezone', {val: aPlace.timezone, ack: true});
+        }
+
+       
+    }
+
+    function cleanUpEvents(home) {
+        adapter.getForeignObjects('netatmo.' + adapter.instance + '.' + home + '.Events.*', 'channel', (errEvents, objEvents) => {
+            if (errEvents) {
+                adapter.log.error(errEvents);
+            } else if (objEvents) {
+                const cleanupDate = new Date().getTime() - EventTime * 60 * 60 * 1000;
+
+                for (const aEventId in objEvents) {
+                    //adapter.getForeignObject(aEventId + '.time', 'state', function (errTime, objTime) {
+                    adapter.getForeignStates(aEventId + '.time', async (errTime, objTime) => {
+                        if (errTime) {
+                            adapter.log.error(errTime);
+                        } else if (objTime) {
+                            for (const aTimeId in objTime) {
+                                let eventDate = null;
+
+                                try {
+                                    eventDate = Date.parse(objTime[aTimeId].val);
+                                } catch(e) {
+                                    eventDate = null;
+                                }
+
+                                if ((cleanupDate > eventDate) || eventDate == null) {
+                                    const parentId = aTimeId.substring(0, aTimeId.length - 5);
+
+                                    adapter.getForeignObjects(parentId + '.*', 'state', async (errState, objState) => {
+                                        if (errState) {
+                                            adapter.log.error(errState);
+                                        } else {
+                                            for (const aStateId in objState) {
+                                                adapter.log.debug(`State ${aStateId} abgelaufen daher löschen!`);
+                                                await adapter.delObjectAsync(aStateId);
+                                            }
+                                        }
+                                    });
+
+                                    adapter.log.info(`Event ${parentId} abgelaufen daher löschen!`);
+                                    await adapter.delObjectAsync(parentId);
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        });
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.netatmo",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "ioBroker netatmo Adapter",
   "author": "Patrick Arns <iobroker@patrick-arns.de>",
   "contributors": [
@@ -11,6 +11,10 @@
     {
       "name": "Peter Weiss",
       "email": "peter.weiss@wep4you.com"
+    },
+    {
+      "name": "Dom",
+      "email": "dom@bugger.ch"
     }
   ],
   "homepage": "https://github.com/PArns/ioBroker.netatmo/",


### PR DESCRIPTION
Update of the current netatmo adapter to support the netatmo smokealarms. (https://www.netatmo.com/en-eu/security/smoke-alarm). Since the smoke alarms lib depends on the realtime events (you don't want to wait for a polling in case of fire), this update relies heavily on the already existing netatmo presence functionality. Including the already existing heroku webhook "bridge". For simplicity the smoke alert lib opens its own connection to the webhook "bridge", obviously causing a bit more load to this service. Both instances ignore events from the other party. If that is unwanted or is causing issues, they both could be combined into one connection, but since that will cause a bigger refactoring on the existing functionality and requires more testing I opted out of it.