### PR TITLE
Support for smoke & carbon monoxide alarm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .DS_Store
 .idea/
 package-lock.json
+
+
+# ioBroker dev-server
+.dev-server/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ the personsId is the id within the "Known" persons folder
 -->
 ## Changelog
 
+### 1.4.6 (2022-01-07)
+* (kyuka-dom) Added support for netatmo carbon monoxide sensor.
+
 ### 1.4.5 (2021-12-29)
 * (kyuka-dom) Added support for netatmo smoke alarm.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ the personsId is the id within the "Known" persons folder
 -->
 ## Changelog
 
+### 1.4.5 (2021-12-29)
+* (kyuka-dom) Added support for netatmo smoke alarm.
+
 ### 1.4.4 (2021-07-21)
 * (Apollon77) Fix typo that lead to a crash
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -22,7 +22,8 @@
         "Coach": {"de": "Health Coach", "en": "Healthy Coach"},
         "Weather": {"de": "Wetter Station", "en": "weather station"},
         "Welcome": {"de": "Welcome Innenkamera", "en": "welcome indoor cam"},
-        "Smokedetector": {"de": "Rauchmelder", "en": "smoke detector"},
+        "CO2": {"de": "CO2 Sensor", "en": "CO2 Sensor"},
+		"Smokedetector": {"de": "Rauchmelder", "en": "smoke detector"},
         "on save adapter restarts with new config immediately": {
             "de": "Beim Speichern von Einstellungen wird der Adapter sofort neu gestartet.",
             "ru": "Сразу после сохранения настроек драйвер перезапуститься с новыми значениями"
@@ -38,9 +39,9 @@
         },
 
         "In order to receive livestreams from Welcome &amp; Presence, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form": {
-            "en": "In order to receive livestreams from Welcome &amp; Presence, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form",
-            "de": "Um Livestreams von Welcome &amp; Presence zu erhalten, musst du einen eigenen API-Schl&uuml;ssel von Netatmo anfordern!<br>Um einen API-Schl&uuml;ssel zu erhalten, klicke bitte auf den folgenden Link und fülle das Formular aus",
-            "ru": "In order to receive livestreams from Welcome &amp; Presence, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form"
+            "en": "In order to receive livestreams from Welcome &amp; Presence, the smoke alarm or the CO2 sensor, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form",
+            "de": "Um Livestreams von Welcome &amp; Presence, dem Rauchmelder oder dem CO2 Sensor zu erhalten, musst du einen eigenen API-Schl&uuml;ssel von Netatmo anfordern!<br>Um einen API-Schl&uuml;ssel zu erhalten, klicke bitte auf den folgenden Link und fülle das Formular aus",
+            "ru": "In order to receive livestreams from Welcome &amp; Presence, the smoke alarm or the CO2 sensor, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form"
         },
         "Client ID": {"en": "Client ID", "de": "Client ID", "ru": "Client ID"},
         "Client Secret": {"en": "Client Secret", "de": "Client Secret", "ru": "Client Secret"},
@@ -116,6 +117,10 @@
 			<td><input type="checkbox" id="netatmoSmokedetector" value="true" class="value"></td>
 		</tr>
 		<tr>
+			<td class="translate">CO2</td>
+			<td><input type="checkbox" id="netatmoCO2Sensor" value="true" class="value"></td>
+		</tr>
+		<tr>
 			<td class="translate">E-Mail</td>
 			<td><input class="value" id="username"></td>
 		</tr>
@@ -149,7 +154,7 @@
 	</table>
 
 	<br/>
-	<b class="translate">In order to receive livestreams from Welcome & Presence or the smoke detector, you've to request your own API key from Netatmo!<br/>To do so, go to the following URL, login with your Netatmo account and fill out the requested form</b>
+	<b class="translate">In order to receive livestreams from Welcome &amp; Presence, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form</b>
 	<a href="https://dev.netatmo.com/dev/createanapp" target="_blank">https://dev.netatmo.com/dev/createanapp</a>
 
 	<br/><br/>

--- a/admin/index.html
+++ b/admin/index.html
@@ -22,6 +22,7 @@
         "Coach": {"de": "Health Coach", "en": "Healthy Coach"},
         "Weather": {"de": "Wetter Station", "en": "weather station"},
         "Welcome": {"de": "Welcome Innenkamera", "en": "welcome indoor cam"},
+        "Smokedetector": {"de": "Rauchmelder", "en": "smoke detector"},
         "on save adapter restarts with new config immediately": {
             "de": "Beim Speichern von Einstellungen wird der Adapter sofort neu gestartet.",
             "ru": "Сразу после сохранения настроек драйвер перезапуститься с новыми значениями"
@@ -110,6 +111,10 @@
 			<td class="translate">Welcome</td>
 			<td><input type="checkbox" id="netatmoWelcome" value="true" class="value"></td>
 		</tr>
+        <tr>
+			<td class="translate">Smokedetector</td>
+			<td><input type="checkbox" id="netatmoSmokedetector" value="true" class="value"></td>
+		</tr>
 		<tr>
 			<td class="translate">E-Mail</td>
 			<td><input class="value" id="username"></td>
@@ -144,7 +149,7 @@
 	</table>
 
 	<br/>
-	<b class="translate">In order to receive livestreams from Welcome & Presence, you've to request your own API key from Netatmo!<br/>To do so, go to the following URL, login with your Netatmo account and fill out the requested form</b>
+	<b class="translate">In order to receive livestreams from Welcome & Presence or the smoke detector, you've to request your own API key from Netatmo!<br/>To do so, go to the following URL, login with your Netatmo account and fill out the requested form</b>
 	<a href="https://dev.netatmo.com/dev/createanapp" target="_blank">https://dev.netatmo.com/dev/createanapp</a>
 
 	<br/><br/>

--- a/admin/index.html
+++ b/admin/index.html
@@ -22,7 +22,7 @@
         "Coach": {"de": "Health Coach", "en": "Healthy Coach"},
         "Weather": {"de": "Wetter Station", "en": "weather station"},
         "Welcome": {"de": "Welcome Innenkamera", "en": "welcome indoor cam"},
-        "CO2": {"de": "CO2 Sensor", "en": "CO2 Sensor"},
+        "CO": {"de": "CO Sensor", "en": "carbon monoxide Sensor"},
 		"Smokedetector": {"de": "Rauchmelder", "en": "smoke detector"},
         "on save adapter restarts with new config immediately": {
             "de": "Beim Speichern von Einstellungen wird der Adapter sofort neu gestartet.",
@@ -39,9 +39,9 @@
         },
 
         "In order to receive livestreams from Welcome &amp; Presence, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form": {
-            "en": "In order to receive livestreams from Welcome &amp; Presence, the smoke alarm or the CO2 sensor, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form",
-            "de": "Um Livestreams von Welcome &amp; Presence, dem Rauchmelder oder dem CO2 Sensor zu erhalten, musst du einen eigenen API-Schl&uuml;ssel von Netatmo anfordern!<br>Um einen API-Schl&uuml;ssel zu erhalten, klicke bitte auf den folgenden Link und fülle das Formular aus",
-            "ru": "In order to receive livestreams from Welcome &amp; Presence, the smoke alarm or the CO2 sensor, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form"
+            "en": "In order to receive livestreams from Welcome &amp; Presence, the smoke alarm or the carbon monoxide sensor, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form",
+            "de": "Um Livestreams von Welcome &amp; Presence, dem Rauchmelder oder dem CO Sensor zu erhalten, musst du einen eigenen API-Schl&uuml;ssel von Netatmo anfordern!<br>Um einen API-Schl&uuml;ssel zu erhalten, klicke bitte auf den folgenden Link und fülle das Formular aus",
+            "ru": "In order to receive livestreams from Welcome &amp; Presence, the smoke alarm or the carbon monoxide sensor, you've to request your own API key from Netatmo!<br>To do so, go to the following URL, login with your Netatmo account and fill out the requested form"
         },
         "Client ID": {"en": "Client ID", "de": "Client ID", "ru": "Client ID"},
         "Client Secret": {"en": "Client Secret", "de": "Client Secret", "ru": "Client Secret"},
@@ -117,8 +117,8 @@
 			<td><input type="checkbox" id="netatmoSmokedetector" value="true" class="value"></td>
 		</tr>
 		<tr>
-			<td class="translate">CO2</td>
-			<td><input type="checkbox" id="netatmoCO2Sensor" value="true" class="value"></td>
+			<td class="translate">CO</td>
+			<td><input type="checkbox" id="netatmoCOSensor" value="true" class="value"></td>
 		</tr>
 		<tr>
 			<td class="translate">E-Mail</td>

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -35,6 +35,10 @@
             "de": "Rauchmelder",
             "en": "smoke detector"
         },
+        "CO2": {
+            "de": "CO2 Sensor",
+            "en": "CO2 sensor"
+        },
         "ClientID": {
             "de": "Client ID",
             "en": "Client ID"
@@ -72,8 +76,8 @@
             "en": "Remove unknown persons last seen older than"
         },
         "live_stream1": {
-            "en": "In order to receive livestreams from Welcome &amp; Presence or to get realtime smoke alerts, you've to request your own API key from Netatmo!",
-            "de": "Um Livestreams von Welcome &amp; Presence zu erhalten oder Rauchmeldungen in Echtzeit, musst du einen eigenen API-Schlüssel von Netatmo anfordern!",
+            "en": "In order to receive livestreams from Welcome &amp; Presence or to get realtime smoke alerts or the CO2 sensor, you've to request your own API key from Netatmo!",
+            "de": "Um Livestreams von Welcome &amp; Presence zu erhalten oder Rauchmeldungen / CO2 Meldungen in Echtzeit, musst du einen eigenen API-Schlüssel von Netatmo anfordern!",
             "ru": "Чтобы получать прямые трансляции от Welcome & amp; Присутствие, вы должны запросить собственный ключ API у Netatmo!"
         },
         "live_stream2": {
@@ -126,6 +130,13 @@
             "md": 6,
             "lg": 3
         },
+        "netatmoCO2Sensor": {
+            "type": "checkbox",
+            "label": "netatmoCO2Sensor",
+            "sm": 12,
+            "md": 6,
+            "lg": 3
+        },
         "username": {
             "newLine": true,
             "type": "text",
@@ -160,7 +171,7 @@
             "lg": 3
         },
         "_header": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
             "type": "header",
             "size": 4,
             "style": {
@@ -170,7 +181,7 @@
             "text": "Welcome & presence camera & smoke detector"
         },
         "cleanup_interval": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
             "type": "number",
             "label": "CleanupIntervall",
             "help": "clean minutes",
@@ -178,7 +189,7 @@
             "lg": 3
         },
         "event_time": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
             "newLine": true,
             "type": "number",
             "label": "RemoveEvents",
@@ -195,26 +206,26 @@
             "lg": 3
         },
         "_text1": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
             "type": "staticText",
             "newLine":  true,
             "text": "live_stream1"
         },
         "_text2": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
             "type": "staticText",
             "newLine":  true,
             "text": "live_stream2"
         },
         "_link": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
             "newLine":  true,
             "type": "staticLink",
             "text": "https://dev.netatmo.com/apps/createanapp",
             "href": "https://auth.netatmo.com/access/login?next_url=https%3A%2F%2Fdev.netatmo.com%2Fapps%2Fcreateanapp"
         },
         "id": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
             "type": "text",
             "newLine": true,
             "label": "Client ID",
@@ -223,7 +234,7 @@
             "lg": 3
         },
         "secret": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
             "type": "password",
             "help": "Netatmo App",
             "label": "Client Secret",

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -35,9 +35,9 @@
             "de": "Rauchmelder",
             "en": "smoke detector"
         },
-        "CO2": {
-            "de": "CO2 Sensor",
-            "en": "CO2 sensor"
+        "CO": {
+            "de": "CO Sensor",
+            "en": "CO sensor"
         },
         "ClientID": {
             "de": "Client ID",
@@ -76,8 +76,8 @@
             "en": "Remove unknown persons last seen older than"
         },
         "live_stream1": {
-            "en": "In order to receive livestreams from Welcome &amp; Presence or to get realtime smoke alerts or the CO2 sensor, you've to request your own API key from Netatmo!",
-            "de": "Um Livestreams von Welcome &amp; Presence zu erhalten oder Rauchmeldungen / CO2 Meldungen in Echtzeit, musst du einen eigenen API-Schlüssel von Netatmo anfordern!",
+            "en": "In order to receive livestreams from Welcome &amp; Presence or to get realtime smoke alerts or the CO sensor, you've to request your own API key from Netatmo!",
+            "de": "Um Livestreams von Welcome &amp; Presence zu erhalten oder Rauchmeldungen / CO Meldungen in Echtzeit, musst du einen eigenen API-Schlüssel von Netatmo anfordern!",
             "ru": "Чтобы получать прямые трансляции от Welcome & amp; Присутствие, вы должны запросить собственный ключ API у Netatmo!"
         },
         "live_stream2": {
@@ -130,9 +130,9 @@
             "md": 6,
             "lg": 3
         },
-        "netatmoCO2Sensor": {
+        "netatmoCOSensor": {
             "type": "checkbox",
-            "label": "netatmoCO2Sensor",
+            "label": "netatmoCOSensor",
             "sm": 12,
             "md": 6,
             "lg": 3
@@ -171,7 +171,7 @@
             "lg": 3
         },
         "_header": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCOSensor",
             "type": "header",
             "size": 4,
             "style": {
@@ -181,7 +181,7 @@
             "text": "Welcome & presence camera & smoke detector"
         },
         "cleanup_interval": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCOSensor",
             "type": "number",
             "label": "CleanupIntervall",
             "help": "clean minutes",
@@ -189,7 +189,7 @@
             "lg": 3
         },
         "event_time": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCOSensor",
             "newLine": true,
             "type": "number",
             "label": "RemoveEvents",
@@ -206,26 +206,26 @@
             "lg": 3
         },
         "_text1": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCOSensor",
             "type": "staticText",
             "newLine":  true,
             "text": "live_stream1"
         },
         "_text2": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCOSensor",
             "type": "staticText",
             "newLine":  true,
             "text": "live_stream2"
         },
         "_link": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCOSensor",
             "newLine":  true,
             "type": "staticLink",
             "text": "https://dev.netatmo.com/apps/createanapp",
             "href": "https://auth.netatmo.com/access/login?next_url=https%3A%2F%2Fdev.netatmo.com%2Fapps%2Fcreateanapp"
         },
         "id": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCOSensor",
             "type": "text",
             "newLine": true,
             "label": "Client ID",
@@ -234,7 +234,7 @@
             "lg": 3
         },
         "secret": {
-            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCO2Sensor",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector && !data.netatmoCOSensor",
             "type": "password",
             "help": "Netatmo App",
             "label": "Client Secret",

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -72,8 +72,8 @@
             "en": "Remove unknown persons last seen older than"
         },
         "live_stream1": {
-            "en": "In order to receive livestreams from Welcome &amp; Presence, you've to request your own API key from Netatmo!",
-            "de": "Um Livestreams von Welcome &amp; Presence zu erhalten, musst du einen eigenen API-Schlüssel von Netatmo anfordern!",
+            "en": "In order to receive livestreams from Welcome &amp; Presence or to get realtime smoke alerts, you've to request your own API key from Netatmo!",
+            "de": "Um Livestreams von Welcome &amp; Presence zu erhalten oder Rauchmeldungen in Echtzeit, musst du einen eigenen API-Schlüssel von Netatmo anfordern!",
             "ru": "Чтобы получать прямые трансляции от Welcome & amp; Присутствие, вы должны запросить собственный ключ API у Netatmo!"
         },
         "live_stream2": {
@@ -160,17 +160,17 @@
             "lg": 3
         },
         "_header": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "header",
             "size": 4,
             "style": {
                 "marginTop": 20
             },
             "sm": 12,
-            "text": "Welcome & presence camera"
+            "text": "Welcome & presence camera & smoke detector"
         },
         "cleanup_interval": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "number",
             "label": "CleanupIntervall",
             "help": "clean minutes",
@@ -178,7 +178,7 @@
             "lg": 3
         },
         "event_time": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "newLine": true,
             "type": "number",
             "label": "RemoveEvents",
@@ -195,26 +195,26 @@
             "lg": 3
         },
         "_text1": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "staticText",
             "newLine":  true,
             "text": "live_stream1"
         },
         "_text2": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "staticText",
             "newLine":  true,
             "text": "live_stream2"
         },
         "_link": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "newLine":  true,
             "type": "staticLink",
             "text": "https://dev.netatmo.com/apps/createanapp",
             "href": "https://auth.netatmo.com/access/login?next_url=https%3A%2F%2Fdev.netatmo.com%2Fapps%2Fcreateanapp"
         },
         "id": {
-            "hidden": "!data.netatmoWelcome || !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "text",
             "newLine": true,
             "label": "Client ID",
@@ -223,7 +223,7 @@
             "lg": 3
         },
         "secret": {
-            "hidden": "!data.netatmoWelcome || !data.netatmoSmokedetector",
+            "hidden": "!data.netatmoWelcome && !data.netatmoSmokedetector",
             "type": "password",
             "help": "Netatmo App",
             "label": "Client Secret",

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -31,6 +31,10 @@
             "de": "Welcome Innenkamera",
             "en": "Welcome indoor cam"
         },
+        "Smokedetector": {
+            "de": "Rauchmelder",
+            "en": "smoke detector"
+        },
         "ClientID": {
             "de": "Client ID",
             "en": "Client ID"
@@ -111,6 +115,13 @@
         "netatmoWelcome": {
             "type": "checkbox",
             "label": "Welcome indoor cam",
+            "sm": 12,
+            "md": 6,
+            "lg": 3
+        },
+         "netatmoSmokedetector": {
+            "type": "checkbox",
+            "label": "Smokedetector",
             "sm": 12,
             "md": 6,
             "lg": 3
@@ -203,7 +214,7 @@
             "href": "https://auth.netatmo.com/access/login?next_url=https%3A%2F%2Fdev.netatmo.com%2Fapps%2Fcreateanapp"
         },
         "id": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome || !data.netatmoSmokedetector",
             "type": "text",
             "newLine": true,
             "label": "Client ID",
@@ -212,7 +223,7 @@
             "lg": 3
         },
         "secret": {
-            "hidden": "!data.netatmoWelcome",
+            "hidden": "!data.netatmoWelcome || !data.netatmoSmokedetector",
             "type": "password",
             "help": "Netatmo App",
             "label": "Client Secret",

--- a/io-package.json
+++ b/io-package.json
@@ -1,12 +1,16 @@
 {
     "common": {
         "name": "netatmo",
-        "version": "1.4.5",
+        "version": "1.4.6",
         "title": "Netatmo",
         "titleLang": {
             "en": "Netatmo"
         },
         "news": {
+            "1.4.6": {
+                "en": "added support for netatmo carbonmonoxide sensor",
+                "de": "Unterstützung für Netatmo CO sensor hinzugefügt."
+            },
             "1.4.5": {
                 "en": "added support for netatmo smokedetector",
                 "de": "Unterstützung für Netatmo Rauchmelder hinzugefügt."

--- a/io-package.json
+++ b/io-package.json
@@ -9,7 +9,7 @@
         "news": {
             "1.4.5": {
                 "en": "added support for netatmo smokedetector",
-                "de": "Unterstützung für Netatmo Rauchmelder hinzugefügt.",
+                "de": "Unterstützung für Netatmo Rauchmelder hinzugefügt."
             },
             "1.4.4": {
                 "en": "Fix typo that lead to a crash",

--- a/io-package.json
+++ b/io-package.json
@@ -1,12 +1,16 @@
 {
     "common": {
         "name": "netatmo",
-        "version": "1.4.4",
+        "version": "1.4.5",
         "title": "Netatmo",
         "titleLang": {
             "en": "Netatmo"
         },
         "news": {
+            "1.4.5": {
+                "en": "added support for netatmo smokedetector",
+                "de": "Unterstützung für Netatmo Rauchmelder hinzugefügt.",
+            },
             "1.4.4": {
                 "en": "Fix typo that lead to a crash",
                 "de": "Tippfehler behoben, der zu einem Absturz führte",
@@ -122,6 +126,7 @@
         "netatmoWeather": true,
         "netatmoWelcome": false,
         "netatmoCoach": false,
+        "netatmoSmokedetector": false,
         "username": "",
         "password": "",
         "check_interval": 5,

--- a/io-package.json
+++ b/io-package.json
@@ -1,20 +1,12 @@
 {
     "common": {
         "name": "netatmo",
-        "version": "1.4.6",
+        "version": "1.4.4",
         "title": "Netatmo",
         "titleLang": {
             "en": "Netatmo"
         },
         "news": {
-            "1.4.6": {
-                "en": "added support for netatmo carbonmonoxide sensor",
-                "de": "Unterstützung für Netatmo CO sensor hinzugefügt."
-            },
-            "1.4.5": {
-                "en": "added support for netatmo smokedetector",
-                "de": "Unterstützung für Netatmo Rauchmelder hinzugefügt."
-            },
             "1.4.4": {
                 "en": "Fix typo that lead to a crash",
                 "de": "Tippfehler behoben, der zu einem Absturz führte",
@@ -131,6 +123,7 @@
         "netatmoWelcome": false,
         "netatmoCoach": false,
         "netatmoSmokedetector": false,
+        "netatmoCOSensor": false,
         "username": "",
         "password": "",
         "check_interval": 5,

--- a/lib/eventEmitterBridge.js
+++ b/lib/eventEmitterBridge.js
@@ -1,0 +1,33 @@
+const {EventEmitter} = require("events");
+const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
+
+module.exports = class eventEmitterBridge extends EventEmitter {
+
+    socket = null;
+
+    constructor() {
+        super();
+        this.socket = require('socket.io-client')(socketServerUrl);
+
+        if (this.socket) {
+            this.socket.on('alert', async data => await this.onSocketAlert(data));
+        }
+    }
+
+    destructor() {
+        if (this.socket) {
+            this.socket.disconnect();
+            this.socket = null;
+        }
+    }
+
+    joinHome(id) {
+        if (this.socket) {
+            this.socket.emit('registerHome', id);
+        }
+    }
+
+    onSocketAlert(data) {
+        this.emit('alert', data)
+    }
+}

--- a/lib/eventEmitterBridge.js
+++ b/lib/eventEmitterBridge.js
@@ -1,33 +1,44 @@
-const {EventEmitter} = require("events");
+const EventEmitter = require('events')
+const inherits = require('util').inherits;
+
+let socket = null;
 const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
 
-module.exports = class eventEmitterBridge extends EventEmitter {
+function eventEmitterBridge() {
+    EventEmitter.call(this);
+}
 
-    socket = null;
+inherits(eventEmitterBridge, EventEmitter);
 
-    constructor() {
-        super();
-        this.socket = require('socket.io-client')(socketServerUrl);
+eventEmitterBridge.prototype.init = function() {
 
-        if (this.socket) {
-            this.socket.on('alert', async data => await this.onSocketAlert(data));
-        }
+    if (!socket)  {
+        console.log('connecting to socket')
+        socket = require('socket.io-client')(socketServerUrl);
     }
 
-    destructor() {
-        if (this.socket) {
-            this.socket.disconnect();
-            this.socket = null;
-        }
+    const _this = this;
+    if (socket) {
+        socket.on('alert', data => onSocketAlert(_this,data));
     }
 
-    joinHome(id) {
-        if (this.socket) {
-            this.socket.emit('registerHome', id);
-        }
-    }
+}
 
-    onSocketAlert(data) {
-        this.emit('alert', data)
+ function onSocketAlert(_this,data) {
+    _this.emit('alert', data)
+}
+
+eventEmitterBridge.prototype.destructor = function() {
+    if (socket) {
+        socket.disconnect();
+        socket = null;
     }
 }
+
+eventEmitterBridge.prototype.joinHome = function(id) {
+    if (socket) {
+        socket.emit('registerHome', id);
+    }
+}
+
+module.exports = eventEmitterBridge;

--- a/lib/netatmoCOSensor.js
+++ b/lib/netatmoCOSensor.js
@@ -405,7 +405,7 @@ module.exports = function (myapi, myadapter) {
             await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.active`, {
                 type: 'state',
                 common: {
-                    name: 'LastEvent',
+                    name: 'active',
                     type: 'boolean',
                     read: true,
                     write: false

--- a/lib/netatmoCOSensor.js
+++ b/lib/netatmoCOSensor.js
@@ -314,7 +314,7 @@ module.exports = function (myapi, myadapter) {
             });
 
             await adapter.setStateAsync(infoPath + '.setup_date', {
-                val: new Date(aCODetector.setup_date * 1000).toLocaleString('en-GB', {timeZone: 'CET'}),
+                val: new Date(aCODetector.setup_date * 1000).toString(),
                 ack: true
             });
         }

--- a/lib/netatmoCOSensor.js
+++ b/lib/netatmoCOSensor.js
@@ -8,26 +8,29 @@ module.exports = function (myapi, myadapter) {
 
     let homeIds = [];
 
-    let socket = null;
     let that = null;
+
+    const eventEmitterBridge = require('./eventEmitterBridge')
+    let eeB = null;
 
     const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
 
     this.init = function () {
         that = this;
-        socket = require('socket.io-client')(socketServerUrl);
 
-        if (socket) {
+        eeB = new eventEmitterBridge()
+
+        if (eeB) {
             adapter.log.info(`Registering realtime events with ${socketServerUrl}`);
-            socket.on('alert', async data => await onSocketAlert(data));
+            eeB.on('alert', async data => await onSocketAlert(data));
             api.addWebHook(socketServerUrl);
         }
     };
 
     this.finalize = function () {
-        if (socket) {
+        if (eeB) {
             adapter.log.info('Unregistering realtime events');
-            socket.disconnect();
+            eeB.destructor();
             api.dropWebHook();
         }
         Object.keys(eventCleanUpTimer).forEach(id => clearInterval(eventCleanUpTimer[id]));
@@ -101,8 +104,8 @@ module.exports = function (myapi, myadapter) {
         homeIds.push(aHome.id);
 
         // Join HomeID
-        if (socket) {
-            socket.emit('registerHome', aHome.id);
+        if (eeB) {
+            eeB.joinHome(aHome.id);
         }
 
         await adapter.setObjectNotExistsAsync(homeName, {

--- a/lib/netatmoCOSensor.js
+++ b/lib/netatmoCOSensor.js
@@ -10,10 +10,17 @@ module.exports = function (myapi, myadapter) {
 
     let that = null;
 
-    const eventEmitterBridge = require('./eventEmitterBridge')
+    const eventEmitterBridge = require('./eventEmitterBridge.js')
     let eeB = null;
 
     const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
+
+    const CODetectorEvents = ["co_detected"]
+    const CODetectorSubtypes = {
+        0: 'OK',
+        1: 'Pre-alarm',
+        2: 'Alarm'
+    }
 
     this.init = function () {
         that = this;
@@ -22,6 +29,7 @@ module.exports = function (myapi, myadapter) {
 
         if (eeB) {
             adapter.log.info(`Registering realtime events with ${socketServerUrl}`);
+            eeB.init();
             eeB.on('alert', async data => await onSocketAlert(data));
             api.addWebHook(socketServerUrl);
         }
@@ -39,7 +47,9 @@ module.exports = function (myapi, myadapter) {
 
     this.requestUpdateCOSensor = function () {
         return new Promise(resolve => {
-            api.getHomeData({}, async (err, data) => {
+            api.homesdata({
+                'gateway_types': 'NCO'
+            }, async (err, data) => {
                 if (err !== null) {
                     adapter.log.error(err);
                 } else {
@@ -50,11 +60,11 @@ module.exports = function (myapi, myadapter) {
                         for (let h = 0; h < homes.length; h++) {
                             const aHome = homes[h];
 
-                            await handleHome(aHome);  // TODO rework the event handling to create a class which notifies all subclasses rather than connects multiple times
+                            await handleHome(aHome);
 
                             const homeName = getHomeName(aHome.name);
 
-                            eventCleanUpTimer[homeName] =  eventCleanUpTimer[homeName] || setInterval(() =>
+                            eventCleanUpTimer[homeName] = eventCleanUpTimer[homeName] || setInterval(() =>
                                 cleanUpEvents(homeName), cleanUpInterval * 60 * 1000);
                         }
                     }
@@ -65,8 +75,7 @@ module.exports = function (myapi, myadapter) {
     };
 
     async function onSocketAlert(data) {
-        // TODO figure out a way to ignore camera events
-        adapter.log.debug(JSON.stringify(data));
+        adapter.log.debug('new alarm (carbon) ' + JSON.stringify(data));
 
         await that.requestUpdateCOSensor();
 
@@ -82,13 +91,29 @@ module.exports = function (myapi, myadapter) {
                 await adapter.setStateAsync(path + 'LastEventId', {val: data.event_id, ack: true});
                 await adapter.setStateAsync(path + 'LastEvent', {val: now, ack: true});
 
-                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.LastEvent`, {val: now, ack: true});
-                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.LastEventId`, {val: data.event_id, ack: true});
-                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: true, ack: true});
-                // reset event after 10 sec
-                setTimeout(async () => {
-                    await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: false, ack: true});
-                }, 10 * 1000);
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.LastEvent`, {
+                    val: now,
+                    ack: true
+                });
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.LastEventId`, {
+                    val: data.event_id,
+                    ack: true
+                });
+
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.SubType`, {
+                    val: CODetectorSubtypes[data.sub_type],
+                    ack: true
+                });
+
+                let active = false
+                if (data.sub_type > 0) {
+                    active = true
+                }
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {
+                    val: active,
+                    ack: true
+                });
+
             }
         }
     }
@@ -191,9 +216,10 @@ module.exports = function (myapi, myadapter) {
             }
         });
 
+        // adapter.log.debug(JSON.stringify(aHome))
 
-        if (aHome.carbonmonoxidedetectors) {
-            aHome.carbonmonoxidedetectors.forEach(async aCODetector => {
+        if (aHome.modules) {
+            aHome.modules.forEach(async aCODetector => {
                 if (aCODetector.id && aCODetector.name) {
                     await adapter.setObjectNotExistsAsync(fullPath + '.' + aCODetector.id, {
                         type: 'state',
@@ -210,8 +236,8 @@ module.exports = function (myapi, myadapter) {
         }
 
         // CO Detector Objects anlegen
-        if (aHome.carbonmonoxidedetectors) {
-            aHome.carbonmonoxidedetectors.forEach(async aCODetector =>
+        if (aHome.modules) {
+            aHome.modules.forEach(async aCODetector =>
                 await handleCODetector(aCODetector, aHome));
         }
 
@@ -242,9 +268,9 @@ module.exports = function (myapi, myadapter) {
 
     async function handleCODetector(aCODetector, aHome) {
         const aParent = getHomeName(aHome.name);
+        const aParentRooms = aHome.rooms;
         const fullPath = aParent + '.' + aCODetector.id;
         const infoPath = fullPath + '.info';
-        const CODetectorEvents = ["co_detected"]
 
         await adapter.setObjectNotExistsAsync(fullPath, {
             type: 'device',
@@ -260,6 +286,8 @@ module.exports = function (myapi, myadapter) {
             }
         });
 
+        // console.log(JSON.stringify(aCODetector))
+
         if (aCODetector.id) {
             await adapter.setObjectNotExistsAsync(infoPath + '.id', {
                 type: 'state',
@@ -274,8 +302,24 @@ module.exports = function (myapi, myadapter) {
         }
 
 
+        if (aCODetector.setup_date) {
+            await adapter.setObjectNotExistsAsync(infoPath + '.setup_date', {
+                type: 'state',
+                common: {
+                    name: 'CODetector setup date',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
 
-        if (aCODetector.name) {
+            await adapter.setStateAsync(infoPath + '.setup_date', {
+                val: new Date(aCODetector.setup_date * 1000).toLocaleString('en-GB', {timeZone: 'CET'}),
+                ack: true
+            });
+        }
+
+        if (aCODetector.setup_date) {
             await adapter.setObjectNotExistsAsync(infoPath + '.name', {
                 type: 'state',
                 common: {
@@ -289,7 +333,25 @@ module.exports = function (myapi, myadapter) {
             await adapter.setStateAsync(infoPath + '.name', {val: aCODetector.name, ack: true});
         }
 
+        if (aCODetector.room_id) {
+            const roomName = aParentRooms.find((r) => r.id == aCODetector.room_id)
+            if (roomName) {
+                await adapter.setObjectNotExistsAsync(infoPath + '.room', {
+                    type: 'state',
+                    common: {
+                        name: 'CODetector Room',
+                        type: 'string',
+                        read: true,
+                        write: false
+                    }
+                });
+
+                await adapter.setStateAsync(infoPath + '.room', {val: roomName.name, ack: true});
+            }
+        }
+
         CODetectorEvents.forEach(async (e) => {
+
             await adapter.setObjectNotExistsAsync(`${fullPath}.${e}`, {
                 type: 'channel',
                 common: {
@@ -304,6 +366,10 @@ module.exports = function (myapi, myadapter) {
                     type: 'string',
                     read: true,
                     write: false
+                },
+                native: {
+                    id: aHome.id,
+                    event: e
                 }
             });
 
@@ -316,9 +382,25 @@ module.exports = function (myapi, myadapter) {
                     write: false
                 },
                 native: {
-                    id: aHome.id
+                    id: aHome.id,
+                    event: e
                 }
             });
+
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.SubType`, {
+                type: 'state',
+                common: {
+                    name: 'SubType',
+                    type: 'string',
+                    read: true,
+                    write: false
+                },
+                native: {
+                    id: aHome.id,
+                    event: e
+                }
+            });
+
 
             await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.active`, {
                 type: 'state',
@@ -329,9 +411,12 @@ module.exports = function (myapi, myadapter) {
                     write: false
                 },
                 native: {
-                    id: aHome.id
+                    id: aHome.id,
+                    event: e
                 }
             });
+
+
         })
 
         // Initialize CODetector Place
@@ -413,7 +498,7 @@ module.exports = function (myapi, myadapter) {
 
                                 try {
                                     eventDate = Date.parse(objTime[aTimeId].val);
-                                } catch(e) {
+                                } catch (e) {
                                     eventDate = null;
                                 }
 

--- a/lib/netatmoCOSensor.js
+++ b/lib/netatmoCOSensor.js
@@ -1,0 +1,441 @@
+module.exports = function (myapi, myadapter) {
+    const api = myapi;
+    const adapter = myadapter;
+    const cleanUpInterval = adapter.config.cleanup_interval ? adapter.config.cleanup_interval : 5;
+    const EventTime = adapter.config.event_time ? adapter.config.event_time : 12;
+
+    const eventCleanUpTimer = {};
+
+    let homeIds = [];
+
+    let socket = null;
+    let that = null;
+
+    const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
+
+    this.init = function () {
+        that = this;
+        socket = require('socket.io-client')(socketServerUrl);
+
+        if (socket) {
+            adapter.log.info(`Registering realtime events with ${socketServerUrl}`);
+            socket.on('alert', async data => await onSocketAlert(data));
+            api.addWebHook(socketServerUrl);
+        }
+    };
+
+    this.finalize = function () {
+        if (socket) {
+            adapter.log.info('Unregistering realtime events');
+            socket.disconnect();
+            api.dropWebHook();
+        }
+        Object.keys(eventCleanUpTimer).forEach(id => clearInterval(eventCleanUpTimer[id]));
+    };
+
+
+    this.requestUpdateCOSensor = function () {
+        return new Promise(resolve => {
+            api.getHomeData({}, async (err, data) => {
+                if (err !== null) {
+                    adapter.log.error(err);
+                } else {
+                    const homes = data.homes;
+                    homeIds = [];
+
+                    if (Array.isArray(homes)) {
+                        for (let h = 0; h < homes.length; h++) {
+                            const aHome = homes[h];
+
+                            await handleHome(aHome);  // TODO rework the event handling to create a class which notifies all subclasses rather than connects multiple times
+
+                            const homeName = getHomeName(aHome.name);
+
+                            eventCleanUpTimer[homeName] =  eventCleanUpTimer[homeName] || setInterval(() =>
+                                cleanUpEvents(homeName), cleanUpInterval * 60 * 1000);
+                        }
+                    }
+                }
+                resolve();
+            });
+        });
+    };
+
+    async function onSocketAlert(data) {
+        // TODO figure out a way to ignore camera events
+        adapter.log.debug(JSON.stringify(data));
+
+        await that.requestUpdateCOSensor();
+
+        const now = new Date().toISOString();
+
+        if (data) {
+            const path = data.home_name + '.LastEventData.';
+            const carbonDetectorEvents = ["co_detected"]
+            if (carbonDetectorEvents.includes(data.event_type)) {
+                await adapter.setStateAsync(path + 'LastPushType', {val: data.push_type, ack: true});
+                await adapter.setStateAsync(path + 'LastEventType', {val: data.event_type, ack: true});
+                await adapter.setStateAsync(path + 'LastEventDeviceId', {val: data.device_id, ack: true});
+                await adapter.setStateAsync(path + 'LastEventId', {val: data.event_id, ack: true});
+                await adapter.setStateAsync(path + 'LastEvent', {val: now, ack: true});
+
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.LastEvent`, {val: now, ack: true});
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.LastEventId`, {val: data.event_id, ack: true});
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: true, ack: true});
+                // reset event after 10 sec
+                setTimeout(async () => {
+                    await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: false, ack: true});
+                }, 10 * 1000);
+            }
+        }
+    }
+
+    function getHomeName(aHomeName) {
+        return aHomeName.replaceAll(' ', '-').replaceAll('---', '-').replaceAll('--', '-');
+    }
+
+    async function handleHome(aHome) {
+        const homeName = getHomeName(aHome.name);
+        const fullPath = homeName;
+
+        homeIds.push(aHome.id);
+
+        // Join HomeID
+        if (socket) {
+            socket.emit('registerHome', aHome.id);
+        }
+
+        await adapter.setObjectNotExistsAsync(homeName, {
+            type: 'channel',
+            common: {
+                name: homeName,
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData', {
+            type: 'channel',
+            common: {
+                name: 'LastEventData',
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastPushType', {
+            type: 'state',
+            common: {
+                name: 'LastPushType',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEventId', {
+            type: 'state',
+            common: {
+                name: 'LastEventId',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEventType', {
+            type: 'state',
+            common: {
+                name: 'LastEventTypes',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEventDeviceId', {
+            type: 'state',
+            common: {
+                name: 'LastEventDeviceId',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEvent', {
+            type: 'state',
+            common: {
+                name: 'LastEvent',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+
+        if (aHome.carbonmonoxidedetectors) {
+            aHome.carbonmonoxidedetectors.forEach(async aCODetector => {
+                if (aCODetector.id && aCODetector.name) {
+                    await adapter.setObjectNotExistsAsync(fullPath + '.' + aCODetector.id, {
+                        type: 'state',
+                        common: {
+                            name: aCODetector.name,
+                            type: 'string',
+                            read: true,
+                            write: false
+                        }
+                    });
+                    await adapter.setStateAsync(fullPath + '.' + aCODetector.id, {val: aCODetector.id, ack: true});
+                }
+            });
+        }
+
+        // CO Detector Objects anlegen
+        if (aHome.carbonmonoxidedetectors) {
+            aHome.carbonmonoxidedetectors.forEach(async aCODetector =>
+                await handleCODetector(aCODetector, aHome));
+        }
+
+
+        // Disabled due to no usage ...
+        /*
+        if (aHome.events) {
+
+            const latestEventDate = 0;
+            const latestEvent = null;
+
+            aHome.events.forEach(function (aEvent) {
+                const eventDate = aEvent.time * 1000;
+
+                handleEvent(aEvent, homeName, aHome.cameras);
+                if (eventDate > latestEventDate) {
+                    latestEventDate = eventDate;
+                    latestEvent = aEvent;
+                }
+            });
+
+            if (latestEvent) {
+                await adapter.setStateAsync(homeName + '.LastEventData.LastEventId', {val: latestEvent.id, ack: true});
+            }
+        }
+         */
+    }
+
+    async function handleCODetector(aCODetector, aHome) {
+        const aParent = getHomeName(aHome.name);
+        const fullPath = aParent + '.' + aCODetector.id;
+        const infoPath = fullPath + '.info';
+        const CODetectorEvents = ["co_detected"]
+
+        await adapter.setObjectNotExistsAsync(fullPath, {
+            type: 'device',
+            common: {
+                name: aCODetector.name,
+                type: 'device',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aCODetector.id,
+                type: aCODetector.type
+            }
+        });
+
+        if (aCODetector.id) {
+            await adapter.setObjectNotExistsAsync(infoPath + '.id', {
+                type: 'state',
+                common: {
+                    name: 'CODetector ID',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+            await adapter.setStateAsync(infoPath + '.id', {val: aCODetector.id, ack: true});
+        }
+
+
+
+        if (aCODetector.name) {
+            await adapter.setObjectNotExistsAsync(infoPath + '.name', {
+                type: 'state',
+                common: {
+                    name: 'CODetector name',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(infoPath + '.name', {val: aCODetector.name, ack: true});
+        }
+
+        CODetectorEvents.forEach(async (e) => {
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}`, {
+                type: 'channel',
+                common: {
+                    name: e,
+                }
+            });
+
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.LastEventId`, {
+                type: 'state',
+                common: {
+                    name: 'LastEventId',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.LastEvent`, {
+                type: 'state',
+                common: {
+                    name: 'LastEvent',
+                    type: 'string',
+                    read: true,
+                    write: false
+                },
+                native: {
+                    id: aHome.id
+                }
+            });
+
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.active`, {
+                type: 'state',
+                common: {
+                    name: 'LastEvent',
+                    type: 'boolean',
+                    read: true,
+                    write: false
+                },
+                native: {
+                    id: aHome.id
+                }
+            });
+        })
+
+        // Initialize CODetector Place
+        if (aHome.place) {
+            await handlePlace(aHome.place, fullPath);
+        }
+    }
+
+    async function handlePlace(aPlace, aParent) {
+        const fullPath = aParent + '.place';
+
+        await adapter.setObjectNotExistsAsync(fullPath, {
+            type: 'channel',
+            common: {
+                name: 'place',
+            }
+        });
+
+        if (aPlace.city) {
+            await adapter.setObjectNotExistsAsync(fullPath + '.city', {
+                type: 'state',
+                common: {
+                    name: 'city',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(fullPath + '.city', {val: aPlace.city, ack: true});
+        }
+
+        if (aPlace.country) {
+            await adapter.setObjectNotExistsAsync(fullPath + '.country', {
+                type: 'state',
+                common: {
+                    name: 'country',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(fullPath + '.country', {val: aPlace.country, ack: true});
+        }
+
+        if (aPlace.timezone) {
+            await adapter.setObjectNotExistsAsync(fullPath + '.timezone', {
+                type: 'state',
+                common: {
+                    name: 'timezone',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(fullPath + '.timezone', {val: aPlace.timezone, ack: true});
+        }
+
+
+    }
+
+    function cleanUpEvents(home) {
+        adapter.getForeignObjects('netatmo.' + adapter.instance + '.' + home + '.Events.*', 'channel', (errEvents, objEvents) => {
+            if (errEvents) {
+                adapter.log.error(errEvents);
+            } else if (objEvents) {
+                const cleanupDate = new Date().getTime() - EventTime * 60 * 60 * 1000;
+
+                for (const aEventId in objEvents) {
+                    //adapter.getForeignObject(aEventId + '.time', 'state', function (errTime, objTime) {
+                    adapter.getForeignStates(aEventId + '.time', async (errTime, objTime) => {
+                        if (errTime) {
+                            adapter.log.error(errTime);
+                        } else if (objTime) {
+                            for (const aTimeId in objTime) {
+                                let eventDate = null;
+
+                                try {
+                                    eventDate = Date.parse(objTime[aTimeId].val);
+                                } catch(e) {
+                                    eventDate = null;
+                                }
+
+                                if ((cleanupDate > eventDate) || eventDate == null) {
+                                    const parentId = aTimeId.substring(0, aTimeId.length - 5);
+
+                                    adapter.getForeignObjects(parentId + '.*', 'state', async (errState, objState) => {
+                                        if (errState) {
+                                            adapter.log.error(errState);
+                                        } else {
+                                            for (const aStateId in objState) {
+                                                adapter.log.debug(`State ${aStateId} abgelaufen daher löschen!`);
+                                                await adapter.delObjectAsync(aStateId);
+                                            }
+                                        }
+                                    });
+
+                                    adapter.log.info(`Event ${parentId} abgelaufen daher löschen!`);
+                                    await adapter.delObjectAsync(parentId);
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        });
+    }
+}

--- a/lib/netatmoLib.js
+++ b/lib/netatmoLib.js
@@ -903,6 +903,67 @@ netatmo.prototype.setThermpoint = function (options, callback) {
 };
 
 /**
+ * https://dev.netatmo.com/doc/methods/homesdata - new call for gethomedata
+ * @param options
+ * @param callback
+ * @returns {*}
+ */
+netatmo.prototype.homesdata = function (options, callback) {
+    // Wait until authenticated.
+    if (!this.access_token) {
+        return this.on('authenticated', () => {
+            this.homesdata(options, callback);
+        });
+    }
+
+    const url = util.format('%s/api/homesdata', BASE_URL);
+
+    const form = {
+        access_token: this.access_token
+    };
+
+    if (options != null && callback == null) {
+        callback = options;
+        options = null;
+    }
+
+    if (options) {
+
+        if (options.home_id) {
+            form.home_id = options.home_id;
+        }
+
+        if (options.gateway_types) {
+            form.gateway_types = options.gateway_types;
+        }
+
+    }
+
+    request({
+        url: url,
+        method: 'POST',
+        form: form,
+    }, (err, response, body) => {
+        if (err || response.statusCode !== 200) {
+            return this.handleRequestError(err, response, body, 'homesdata error', false, callback, this.homesdata.bind(this, options, callback));
+        }
+
+        body = JSON.parse(body);
+
+        this.emit('get-homesdata', err, body.body);
+
+        if (callback) {
+            return callback(err, body.body);
+        }
+
+        return this;
+
+    });
+
+    return this;
+}
+
+/**
  * https://dev.netatmo.com/doc/methods/gethomedata
  * @param options
  * @param callback

--- a/lib/netatmoSmokedetector.js
+++ b/lib/netatmoSmokedetector.js
@@ -3,12 +3,9 @@ module.exports = function (myapi, myadapter) {
     const adapter = myadapter;
     const cleanUpInterval = adapter.config.cleanup_interval ? adapter.config.cleanup_interval : 5;
     const EventTime = adapter.config.event_time ? adapter.config.event_time : 12;
-    const UnknownPersonTime = adapter.config.unknown_person_time ? adapter.config.unknown_person_time : 24;
 
     const eventCleanUpTimer = {};
-    const personCleanUpTimer = {};
 
-    let knownPeople = [];
     let homeIds = [];
 
     let socket = null;
@@ -87,7 +84,7 @@ module.exports = function (myapi, myadapter) {
                 await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: true, ack: true});
                 // reset event after 10 sec
                 setTimeout(async () => {
-                    await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: false, ack: false});
+                    await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: false, ack: true});
                 }, 10 * 1000);
             }
         }

--- a/lib/netatmoSmokedetector.js
+++ b/lib/netatmoSmokedetector.js
@@ -11,7 +11,7 @@ module.exports = function (myapi, myadapter) {
 
     let that = null;
 
-    const eventEmitterBridge = require('./eventEmitterBridge')
+    const eventEmitterBridge = require('./eventEmitterBridge.js')
     let eeB = null;
 
     const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
@@ -23,6 +23,7 @@ module.exports = function (myapi, myadapter) {
 
         if (eeB) {
             adapter.log.info(`Registering realtime events with ${socketServerUrl}`);
+            eeB.init();
             eeB.on('alert', async data => await onSocketAlert(data));
             api.addWebHook(socketServerUrl);
         }
@@ -51,7 +52,7 @@ module.exports = function (myapi, myadapter) {
                         for (let h = 0; h < homes.length; h++) {
                             const aHome = homes[h];
 
-                            await handleHome(aHome);  // TODO check if it's an issue that the same homeId is subscribed twice in case of smoke & cameras
+                            await handleHome(aHome);
 
                             const homeName = getHomeName(aHome.name);
 
@@ -66,8 +67,7 @@ module.exports = function (myapi, myadapter) {
     };
 
     async function onSocketAlert(data) {
-        // TODO figure out a way to ignore camera events
-        adapter.log.debug(JSON.stringify(data));
+        adapter.log.debug('new alarm (smoke) ' + JSON.stringify(data));
 
         await that.requestUpdateSmokedetector();
 

--- a/lib/netatmoSmokedetector.js
+++ b/lib/netatmoSmokedetector.js
@@ -324,7 +324,7 @@ module.exports = function (myapi, myadapter) {
             await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.active`, {
                 type: 'state',
                 common: {
-                    name: 'LastEvent',
+                    name: 'active',
                     type: 'boolean',
                     read: true,
                     write: false

--- a/lib/netatmoSmokedetector.js
+++ b/lib/netatmoSmokedetector.js
@@ -8,26 +8,30 @@ module.exports = function (myapi, myadapter) {
 
     let homeIds = [];
 
-    let socket = null;
+
     let that = null;
+
+    const eventEmitterBridge = require('./eventEmitterBridge')
+    let eeB = null;
 
     const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
 
     this.init = function () {
         that = this;
-        socket = require('socket.io-client')(socketServerUrl);
 
-        if (socket) {
+        eeB = new eventEmitterBridge()
+
+        if (eeB) {
             adapter.log.info(`Registering realtime events with ${socketServerUrl}`);
-            socket.on('alert', async data => await onSocketAlert(data));
+            eeB.on('alert', async data => await onSocketAlert(data));
             api.addWebHook(socketServerUrl);
         }
     };
 
     this.finalize = function () {
-        if (socket) {
+        if (eeB) {
             adapter.log.info('Unregistering realtime events');
-            socket.disconnect();
+            eeB.destructor();
             api.dropWebHook();
         }
         Object.keys(eventCleanUpTimer).forEach(id => clearInterval(eventCleanUpTimer[id]));
@@ -101,8 +105,8 @@ module.exports = function (myapi, myadapter) {
         homeIds.push(aHome.id);
 
         // Join HomeID
-        if (socket) {
-            socket.emit('registerHome', aHome.id);
+        if (eeB) {
+            eeB.joinHome(aHome.id);
         }
 
         await adapter.setObjectNotExistsAsync(homeName, {
@@ -270,7 +274,7 @@ module.exports = function (myapi, myadapter) {
             await adapter.setStateAsync(infoPath + '.id', {val: aSmokeDetector.id, ack: true});
         }
 
-        
+
 
         if (aSmokeDetector.name) {
             await adapter.setObjectNotExistsAsync(infoPath + '.name', {
@@ -389,7 +393,7 @@ module.exports = function (myapi, myadapter) {
             await adapter.setStateAsync(fullPath + '.timezone', {val: aPlace.timezone, ack: true});
         }
 
-       
+
     }
 
     function cleanUpEvents(home) {

--- a/lib/netatmoSmokedetector.js
+++ b/lib/netatmoSmokedetector.js
@@ -1,0 +1,444 @@
+module.exports = function (myapi, myadapter) {
+    const api = myapi;
+    const adapter = myadapter;
+    const cleanUpInterval = adapter.config.cleanup_interval ? adapter.config.cleanup_interval : 5;
+    const EventTime = adapter.config.event_time ? adapter.config.event_time : 12;
+    const UnknownPersonTime = adapter.config.unknown_person_time ? adapter.config.unknown_person_time : 24;
+
+    const eventCleanUpTimer = {};
+    const personCleanUpTimer = {};
+
+    let knownPeople = [];
+    let homeIds = [];
+
+    let socket = null;
+    let that = null;
+
+    const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
+
+    this.init = function () {
+        that = this;
+        socket = require('socket.io-client')(socketServerUrl);
+
+        if (socket) {
+            adapter.log.info(`Registering realtime events with ${socketServerUrl}`);
+            socket.on('alert', async data => await onSocketAlert(data));
+            api.addWebHook(socketServerUrl);
+        }
+    };
+
+    this.finalize = function () {
+        if (socket) {
+            adapter.log.info('Unregistering realtime events');
+            socket.disconnect();
+            api.dropWebHook();
+        }
+        Object.keys(eventCleanUpTimer).forEach(id => clearInterval(eventCleanUpTimer[id]));
+    };
+
+
+    this.requestUpdateSmokedetector = function () {
+        return new Promise(resolve => {
+            api.getHomeData({}, async (err, data) => {
+                if (err !== null) {
+                    adapter.log.error(err);
+                } else {
+                    const homes = data.homes;
+                    homeIds = [];
+
+                    if (Array.isArray(homes)) {
+                        for (let h = 0; h < homes.length; h++) {
+                            const aHome = homes[h];
+
+                            await handleHome(aHome);  // TODO check if it's an issue that the same homeId is subscribed twice in case of smoke & cameras
+
+                            const homeName = getHomeName(aHome.name);
+
+                            eventCleanUpTimer[homeName] =  eventCleanUpTimer[homeName] || setInterval(() =>
+                                cleanUpEvents(homeName), cleanUpInterval * 60 * 1000);
+                        }
+                    }
+                }
+                resolve();
+            });
+        });
+    };
+
+    async function onSocketAlert(data) {
+        // TODO figure out a way to ignore camera events
+        adapter.log.debug(JSON.stringify(data));
+
+        await that.requestUpdateSmokedetector();
+
+        const now = new Date().toISOString();
+
+        if (data) {
+            const path = data.home_name + '.LastEventData.';
+            const smokeDetectorEvents = ["sound_test","detection_chamber_status","battery_status","wifi_status","tampered","smoke","hush"]
+            if (smokeDetectorEvents.includes(data.event_type)) {
+                await adapter.setStateAsync(path + 'LastPushType', {val: data.push_type, ack: true});
+                await adapter.setStateAsync(path + 'LastEventType', {val: data.event_type, ack: true});
+                await adapter.setStateAsync(path + 'LastEventDeviceId', {val: data.device_id, ack: true});
+                await adapter.setStateAsync(path + 'LastEventId', {val: data.event_id, ack: true});
+                await adapter.setStateAsync(path + 'LastEvent', {val: now, ack: true});
+
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.LastEvent`, {val: now, ack: true});
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.LastEventId`, {val: data.event_id, ack: true});
+                await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: true, ack: true});
+                // reset event after 10 sec
+                setTimeout(async () => {
+                    await adapter.setStateAsync(`${data.home_name}.${data.device_id}.${data.event_type}.active`, {val: false, ack: false});
+                }, 10 * 1000);
+            }
+        }
+    }
+
+    function getHomeName(aHomeName) {
+        return aHomeName.replaceAll(' ', '-').replaceAll('---', '-').replaceAll('--', '-');
+    }
+
+    async function handleHome(aHome) {
+        const homeName = getHomeName(aHome.name);
+        const fullPath = homeName;
+
+        homeIds.push(aHome.id);
+
+        // Join HomeID
+        if (socket) {
+            socket.emit('registerHome', aHome.id);
+        }
+
+        await adapter.setObjectNotExistsAsync(homeName, {
+            type: 'channel',
+            common: {
+                name: homeName,
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData', {
+            type: 'channel',
+            common: {
+                name: 'LastEventData',
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastPushType', {
+            type: 'state',
+            common: {
+                name: 'LastPushType',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEventId', {
+            type: 'state',
+            common: {
+                name: 'LastEventId',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEventType', {
+            type: 'state',
+            common: {
+                name: 'LastEventTypes',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEventDeviceId', {
+            type: 'state',
+            common: {
+                name: 'LastEventDeviceId',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+        await adapter.setObjectNotExistsAsync(homeName + '.LastEventData.LastEvent', {
+            type: 'state',
+            common: {
+                name: 'LastEvent',
+                type: 'string',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aHome.id
+            }
+        });
+
+
+        if (aHome.smokedetectors) {
+            aHome.smokedetectors.forEach(async aSmokeDetector => {
+                if (aSmokeDetector.id && aSmokeDetector.name) {
+                    await adapter.setObjectNotExistsAsync(fullPath + '.' + aSmokeDetector.id, {
+                        type: 'state',
+                        common: {
+                            name: aSmokeDetector.name,
+                            type: 'string',
+                            read: true,
+                            write: false
+                        }
+                    });
+                    await adapter.setStateAsync(fullPath + '.' + aSmokeDetector.id, {val: aSmokeDetector.id, ack: true});
+                }
+            });
+        }
+
+        // Smoke Detector Objects anlegen
+        if (aHome.smokedetectors) {
+            aHome.smokedetectors.forEach(async aSmokeDetector =>
+                await handleSmokeDetector(aSmokeDetector, aHome));
+        }
+
+
+        // Disabled due to no usage ...
+        /*
+        if (aHome.events) {
+
+            const latestEventDate = 0;
+            const latestEvent = null;
+
+            aHome.events.forEach(function (aEvent) {
+                const eventDate = aEvent.time * 1000;
+
+                handleEvent(aEvent, homeName, aHome.cameras);
+                if (eventDate > latestEventDate) {
+                    latestEventDate = eventDate;
+                    latestEvent = aEvent;
+                }
+            });
+
+            if (latestEvent) {
+                await adapter.setStateAsync(homeName + '.LastEventData.LastEventId', {val: latestEvent.id, ack: true});
+            }
+        }
+         */
+    }
+
+    async function handleSmokeDetector(aSmokeDetector, aHome) {
+        const aParent = getHomeName(aHome.name);
+        const fullPath = aParent + '.' + aSmokeDetector.id;
+        const infoPath = fullPath + '.info';
+        const smokeDetectorEvents = ["sound_test","detection_chamber_status","battery_status","wifi_status","tampered","smoke","hush"]
+
+        await adapter.setObjectNotExistsAsync(fullPath, {
+            type: 'device',
+            common: {
+                name: aSmokeDetector.name,
+                type: 'device',
+                read: true,
+                write: false
+            },
+            native: {
+                id: aSmokeDetector.id,
+                type: aSmokeDetector.type
+            }
+        });
+
+        if (aSmokeDetector.id) {
+            await adapter.setObjectNotExistsAsync(infoPath + '.id', {
+                type: 'state',
+                common: {
+                    name: 'SmokeDetector ID',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+            await adapter.setStateAsync(infoPath + '.id', {val: aSmokeDetector.id, ack: true});
+        }
+
+        
+
+        if (aSmokeDetector.name) {
+            await adapter.setObjectNotExistsAsync(infoPath + '.name', {
+                type: 'state',
+                common: {
+                    name: 'SmokeDetector name',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(infoPath + '.name', {val: aSmokeDetector.name, ack: true});
+        }
+
+        smokeDetectorEvents.forEach(async (e) => {
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}`, {
+                type: 'channel',
+                common: {
+                    name: e,
+                }
+            });
+
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.LastEventId`, {
+                type: 'state',
+                common: {
+                    name: 'LastEventId',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.LastEvent`, {
+                type: 'state',
+                common: {
+                    name: 'LastEvent',
+                    type: 'string',
+                    read: true,
+                    write: false
+                },
+                native: {
+                    id: aHome.id
+                }
+            });
+
+            await adapter.setObjectNotExistsAsync(`${fullPath}.${e}.active`, {
+                type: 'state',
+                common: {
+                    name: 'LastEvent',
+                    type: 'boolean',
+                    read: true,
+                    write: false
+                },
+                native: {
+                    id: aHome.id
+                }
+            });
+        })
+
+         // Initialize SmokeDetector Place
+        if (aHome.place) {
+            await handlePlace(aHome.place, fullPath);
+        }
+    }
+
+    async function handlePlace(aPlace, aParent) {
+        const fullPath = aParent + '.place';
+
+        await adapter.setObjectNotExistsAsync(fullPath, {
+            type: 'channel',
+            common: {
+                name: 'place',
+            }
+        });
+
+        if (aPlace.city) {
+            await adapter.setObjectNotExistsAsync(fullPath + '.city', {
+                type: 'state',
+                common: {
+                    name: 'city',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(fullPath + '.city', {val: aPlace.city, ack: true});
+        }
+
+        if (aPlace.country) {
+            await adapter.setObjectNotExistsAsync(fullPath + '.country', {
+                type: 'state',
+                common: {
+                    name: 'country',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(fullPath + '.country', {val: aPlace.country, ack: true});
+        }
+
+        if (aPlace.timezone) {
+            await adapter.setObjectNotExistsAsync(fullPath + '.timezone', {
+                type: 'state',
+                common: {
+                    name: 'timezone',
+                    type: 'string',
+                    read: true,
+                    write: false
+                }
+            });
+
+            await adapter.setStateAsync(fullPath + '.timezone', {val: aPlace.timezone, ack: true});
+        }
+
+       
+    }
+
+    function cleanUpEvents(home) {
+        adapter.getForeignObjects('netatmo.' + adapter.instance + '.' + home + '.Events.*', 'channel', (errEvents, objEvents) => {
+            if (errEvents) {
+                adapter.log.error(errEvents);
+            } else if (objEvents) {
+                const cleanupDate = new Date().getTime() - EventTime * 60 * 60 * 1000;
+
+                for (const aEventId in objEvents) {
+                    //adapter.getForeignObject(aEventId + '.time', 'state', function (errTime, objTime) {
+                    adapter.getForeignStates(aEventId + '.time', async (errTime, objTime) => {
+                        if (errTime) {
+                            adapter.log.error(errTime);
+                        } else if (objTime) {
+                            for (const aTimeId in objTime) {
+                                let eventDate = null;
+
+                                try {
+                                    eventDate = Date.parse(objTime[aTimeId].val);
+                                } catch(e) {
+                                    eventDate = null;
+                                }
+
+                                if ((cleanupDate > eventDate) || eventDate == null) {
+                                    const parentId = aTimeId.substring(0, aTimeId.length - 5);
+
+                                    adapter.getForeignObjects(parentId + '.*', 'state', async (errState, objState) => {
+                                        if (errState) {
+                                            adapter.log.error(errState);
+                                        } else {
+                                            for (const aStateId in objState) {
+                                                adapter.log.debug(`State ${aStateId} abgelaufen daher löschen!`);
+                                                await adapter.delObjectAsync(aStateId);
+                                            }
+                                        }
+                                    });
+
+                                    adapter.log.info(`Event ${parentId} abgelaufen daher löschen!`);
+                                    await adapter.delObjectAsync(parentId);
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        });
+    }
+}

--- a/lib/netatmoWelcome.js
+++ b/lib/netatmoWelcome.js
@@ -1,4 +1,3 @@
-const eventEmitterBridge = require("./eventEmitterBridge");
 module.exports = function (myapi, myadapter) {
     const api = myapi;
     const adapter = myadapter;
@@ -12,25 +11,26 @@ module.exports = function (myapi, myadapter) {
     let knownPeople = [];
     let homeIds = [];
 
-    const eventEmitterBridge = require('./eventEmitterBridge')
-    let eeB = null;
     let that = null;
+    const eventEmitterBridge = require('./eventEmitterBridge.js')
+    let eeB = null;
 
     const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
 
     this.init = function () {
         that = this;
-        eeB = new eventEmitterBridge()
 
+        eeB = new eventEmitterBridge()
         if (eeB) {
             adapter.log.info(`Registering realtime events with ${socketServerUrl}`);
+            eeB.init();
             eeB.on('alert', async data => await onSocketAlert(data));
             api.addWebHook(socketServerUrl);
         }
     };
 
     this.finalize = function () {
-        if (eeb) {
+        if (eeB) {
             adapter.log.info('Unregistering realtime events');
             eeB.destructor();
             api.dropWebHook();
@@ -80,7 +80,7 @@ module.exports = function (myapi, myadapter) {
     };
 
     async function onSocketAlert(data) {
-        adapter.log.debug(JSON.stringify(data));
+        adapter.log.debug('new alarm (welcome) ' + JSON.stringify(data));
 
         await that.requestUpdateIndoorCamera();
 

--- a/lib/netatmoWelcome.js
+++ b/lib/netatmoWelcome.js
@@ -1,3 +1,4 @@
+const eventEmitterBridge = require("./eventEmitterBridge");
 module.exports = function (myapi, myadapter) {
     const api = myapi;
     const adapter = myadapter;
@@ -11,26 +12,27 @@ module.exports = function (myapi, myadapter) {
     let knownPeople = [];
     let homeIds = [];
 
-    let socket = null;
+    const eventEmitterBridge = require('./eventEmitterBridge')
+    let eeB = null;
     let that = null;
 
     const socketServerUrl = 'https://iobroker.herokuapp.com/netatmo/';
 
     this.init = function () {
         that = this;
-        socket = require('socket.io-client')(socketServerUrl);
+        eeB = new eventEmitterBridge()
 
-        if (socket) {
+        if (eeB) {
             adapter.log.info(`Registering realtime events with ${socketServerUrl}`);
-            socket.on('alert', async data => await onSocketAlert(data));
+            eeB.on('alert', async data => await onSocketAlert(data));
             api.addWebHook(socketServerUrl);
         }
     };
 
     this.finalize = function () {
-        if (socket) {
+        if (eeb) {
             adapter.log.info('Unregistering realtime events');
-            socket.disconnect();
+            eeB.destructor();
             api.dropWebHook();
         }
         Object.keys(eventCleanUpTimer).forEach(id => clearInterval(eventCleanUpTimer[id]));
@@ -200,8 +202,8 @@ module.exports = function (myapi, myadapter) {
         homeIds.push(aHome.id);
 
         // Join HomeID
-        if (socket) {
-            socket.emit('registerHome', aHome.id);
+        if (eeB) {
+            eeB.joinHome(aHome.id);
         }
 
         await adapter.setObjectNotExistsAsync(homeName, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.netatmo",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "ioBroker netatmo Adapter",
   "author": "Patrick Arns <iobroker@patrick-arns.de>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.netatmo",
-  "version": "1.4.6",
+  "version": "1.4.4",
   "description": "ioBroker netatmo Adapter",
   "author": "Patrick Arns <iobroker@patrick-arns.de>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.netatmo",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "ioBroker netatmo Adapter",
   "author": "Patrick Arns <iobroker@patrick-arns.de>",
   "contributors": [
@@ -11,6 +11,10 @@
     {
       "name": "Peter Weiss",
       "email": "peter.weiss@wep4you.com"
+    },
+    {
+      "name": "Dom",
+      "email": "dom@bugger.ch"
     }
   ],
   "homepage": "https://github.com/PArns/ioBroker.netatmo/",


### PR DESCRIPTION
* added support for smokealarms. objects are being generated for each existing smokealarm including states for all the different possible events
* added support for carbon monoxide sensors. Objects are being generated for each existing co sensor including states for all the different possible events. 
* added preliminary support for the "new" homesdata api call (which replaces getHomedata). Currently only in use for the new carbon monoxide alarm.
* since welcome, presence, smoke alarm & co sensor all share the same event webhooks I created a singelton bridge making sure that only one socket connection to the webhook backend is created